### PR TITLE
Hex values for custom properties are lost during format

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1014,7 +1014,7 @@ fn parse_dimension(dimension: &Dimension) -> PrintItems {
 
 fn parse_number(number: &Number) -> PrintItems {
     let mut items = PrintItems::new();
-    items.push_string(number.value.to_string());
+    items.push_string(number.raw.to_string());
     items
 }
 

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -453,7 +453,7 @@ fn gen_selector_instruction(simple_selector: &SimpleSelector) -> PrintItems {
                         }
                     },
                     raffia::ast::PseudoClassSelectorArg::Number(number) => {
-                        items.push_string(number.value.to_string())
+                        items.extend(parse_number(number))
                     }
                     raffia::ast::PseudoClassSelectorArg::RelativeSelectorList(
                         relative_selector_list,

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -881,11 +881,14 @@ fn parse_component_values(values: &[ComponentValue]) -> PrintItems {
     for (i, value) in values.iter().enumerate() {
         items.extend(parse_component_value(value));
         let next_node = values.get(i + 1);
-        match next_node {
-            None | Some(ComponentValue::Delimiter(_)) => (),
-            Some(ComponentValue::TokenWithSpan(next_token)) => {
+        match (value, next_node) {
+            (_, None | Some(ComponentValue::Delimiter(_))) => (),
+            (ComponentValue::TokenWithSpan(token), Some(_)) if token.token.is_comma() => {
+                items.push_signal(Signal::SpaceOrNewLine);
+            }
+            (_, Some(ComponentValue::TokenWithSpan(next_token))) => {
                 if next_token.span.start > value.span().end {
-                    items.push_signal(Signal::SpaceOrNewLine)
+                    items.push_signal(Signal::SpaceOrNewLine);
                 }
             }
             _ => items.push_signal(Signal::SpaceOrNewLine),

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1064,7 +1064,10 @@ fn parse_token_with_span(node: &TokenWithSpan) -> PrintItems {
         raffia::token::Token::ExclamationEqual(_) => items.push_str("!="),
         raffia::token::Token::GreaterThan(_) => items.push_str(">"),
         raffia::token::Token::GreaterThanEqual(_) => items.push_str(">="),
-        raffia::token::Token::Hash(_) => items.push_str("#"),
+        raffia::token::Token::Hash(hash) => {
+            items.push_str("#");
+            items.push_str(hash.raw);
+        }
         raffia::token::Token::HashLBrace(_) => items.push_str("#{"),
         raffia::token::Token::Ident(ident) => items.push_str(ident.raw),
         raffia::token::Token::Indent(_) => items.push_str("<indent>"),

--- a/tests/specs/at-rule/media.txt
+++ b/tests/specs/at-rule/media.txt
@@ -468,7 +468,7 @@
 
 @media (max-aspect-ratio: 1/1), not all and (max-aspect-ratio: 1/1) {}
 
-@media (max-aspect-ratio: 1/1), not all and (max-aspect-ratio: 1/1) {}
+@media (max-aspect-ratio: 1.0/1), not all and (max-aspect-ratio: 1.0/1) {}
 
 @media (max-aspect-ratio: 0/1), not all and (max-aspect-ratio: 0/1) {}
 

--- a/tests/specs/value/color.txt
+++ b/tests/specs/value/color.txt
@@ -18,6 +18,6 @@ div {
     prop: #e3e4e5;
     --custom1: rgba(255, 255, 255, 0.4);
     --custom2: oklch(70% 0.1 9);
-    --custom1: #eee;
-    --custom2: #e3e4e5;
+    --custom3: #eee;
+    --custom4: #e3e4e5;
 }

--- a/tests/specs/value/color.txt
+++ b/tests/specs/value/color.txt
@@ -1,4 +1,4 @@
-== should format bracket block value ==
+== should format colors for properties and custom properties ==
 div {
   prop:  rgba(255,255,255,.4);
   prop: oklch(70% 0.1 9);

--- a/tests/specs/value/color.txt
+++ b/tests/specs/value/color.txt
@@ -12,7 +12,7 @@ div {
 
 [expect]
 div {
-    prop: rgba(255, 255, 255, 0.4);
+    prop: rgba(255, 255, 255, .4);
     prop: oklch(70% 0.1 9);
     prop: #eee;
     prop: #e3e4e5;

--- a/tests/specs/value/color.txt
+++ b/tests/specs/value/color.txt
@@ -16,7 +16,7 @@ div {
     prop: oklch(70% 0.1 9);
     prop: #eee;
     prop: #e3e4e5;
-    --custom1: rgba(255, 255, 255, 0.4);
+    --custom1: rgba(255, 255, 255, .4);
     --custom2: oklch(70% 0.1 9);
     --custom3: #eee;
     --custom4: #e3e4e5;

--- a/tests/specs/value/color.txt
+++ b/tests/specs/value/color.txt
@@ -1,0 +1,23 @@
+== should format bracket block value ==
+div {
+  prop:  rgba(255,255,255,.4);
+  prop: oklch(70% 0.1 9);
+  prop: #eee;
+  prop: #e3e4e5;
+   --custom1:  rgba(255,255,255,.4);
+  --custom2: oklch(70% 0.1  9);
+  --custom3: #eee;
+  --custom4: #e3e4e5;
+}
+
+[expect]
+div {
+    prop: rgba(255, 255, 255, 0.4);
+    prop: oklch(70% 0.1 9);
+    prop: #eee;
+    prop: #e3e4e5;
+    --custom1: rgba(255, 255, 255, 0.4);
+    --custom2: oklch(70% 0.1 9);
+    --custom1: #eee;
+    --custom2: #e3e4e5;
+}


### PR DESCRIPTION
I'm not sure why this is happening, but I was able to write a failing test for it so I hope that helps a little.