### PR TITLE
refactor: use raw number format

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -981,7 +981,7 @@ fn parse_dimension(dimension: &Dimension) -> PrintItems {
     let mut items = PrintItems::new();
     match dimension {
         Dimension::Length(len) => {
-            items.push_string(len.value.value.to_string());
+            items.push_str(len.value.raw);
             items.push_str(&len.unit.name);
         }
         Dimension::Angle(angle) => {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -433,7 +433,7 @@ fn gen_selector_instruction(simple_selector: &SimpleSelector) -> PrintItems {
                     raffia::ast::PseudoClassSelectorArg::Nth(nth) => match nth {
                         raffia::ast::Nth::Odd(odd) => items.push_str(&odd.name),
                         raffia::ast::Nth::Even(even) => items.push_str(&even.name),
-                        raffia::ast::Nth::Integer(int) => items.push_string(int.value.to_string()),
+                        raffia::ast::Nth::Integer(int) => items.push_str(int.raw),
                         raffia::ast::Nth::AnPlusB(an_plus_b) => {
                             if an_plus_b.a.is_negative() {
                                 items.push_str("-");

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -279,7 +279,7 @@ fn gen_keyframe_block(node: KeyframeBlock) -> PrintItems {
                 items.extend(parse_interpolable_ident(ident))
             }
             raffia::ast::KeyframeSelector::Percentage(percentage) => {
-                items.push_string(percentage.value.value.to_string());
+                items.push_str(percentage.value.raw);
                 items.push_str("%");
             }
         }
@@ -929,7 +929,7 @@ fn parse_component_value(value: &ComponentValue) -> PrintItems {
         }
         ComponentValue::Number(node) => items.extend(parse_number(node)),
         ComponentValue::Percentage(node) => {
-            items.push_string(node.value.value.to_string());
+            items.push_str(node.value.raw);
             items.push_str("%");
         }
         ComponentValue::Ratio(node) => items.extend(parse_ratio(node)),
@@ -985,27 +985,27 @@ fn parse_dimension(dimension: &Dimension) -> PrintItems {
             items.push_str(&len.unit.name);
         }
         Dimension::Angle(angle) => {
-            items.push_string(angle.value.value.to_string());
+            items.push_str(angle.value.raw);
             items.push_str(&angle.unit.name);
         }
         Dimension::Duration(duration) => {
-            items.push_string(duration.value.value.to_string());
+            items.push_str(duration.value.raw);
             items.push_str(&duration.unit.name);
         }
         Dimension::Frequency(frequency) => {
-            items.push_string(frequency.value.value.to_string());
+            items.push_str(frequency.value.raw);
             items.push_str(&frequency.unit.name);
         }
         Dimension::Resolution(resolution) => {
-            items.push_string(resolution.value.value.to_string());
+            items.push_str(resolution.value.raw);
             items.push_str(&resolution.unit.name);
         }
         Dimension::Flex(flex) => {
-            items.push_string(flex.value.value.to_string());
+            items.push_str(flex.value.raw);
             items.push_str(&flex.unit.name);
         }
         Dimension::Unknown(unknown) => {
-            items.push_string(unknown.value.value.to_string());
+            items.push_str(unknown.value.raw);
             items.push_str(&unknown.unit.name);
         }
     }

--- a/tests/specs/at-rule/media.txt
+++ b/tests/specs/at-rule/media.txt
@@ -476,7 +476,7 @@
 
 @media (resolution: 3dpi), not all and (resolution: 3dpi) {}
 
-@media (resolution: 3dpi), not all and (resolution: 3dpi) {}
+@media (resolution: 3.0dpi), not all and (resolution: 3.0dpi) {}
 
 @media (resolution: 120dpcm), not all and (resolution: 120dpcm) {}
 

--- a/tests/specs/selectors/nesting.txt
+++ b/tests/specs/selectors/nesting.txt
@@ -88,7 +88,7 @@ figure {
         background: hsl(0 0% 0% / 50%);
 
         & > p {
-            font-size: 0.9rem;
+            font-size: .9rem;
         }
     }
 }

--- a/tests/specs/selectors/selectors_pseudo_class.txt
+++ b/tests/specs/selectors/selectors_pseudo_class.txt
@@ -223,19 +223,19 @@ a:hOvEr {}
 
 :nth-child(0) {}
 
-:nth-child(0) {}
+:nth-child(+0) {}
 
 :nth-child(-0) {}
 
 :nth-child(1) {}
 
-:nth-child(1) {}
+:nth-child(+1) {}
 
 :nth-child(-1) {}
 
 :nth-child(3) {}
 
-:nth-child(3) {}
+:nth-child(+3) {}
 
 :nth-child(-3) {}
 

--- a/tests/specs/value/calc.txt
+++ b/tests/specs/value/calc.txt
@@ -6,6 +6,7 @@
 div {
   --width: calc(10% + 30px);
 
+  width: calc(.9%);
   width: calc(0px);
   line-height: calc(0);
   line-height: calc(2 + 3 * 4);
@@ -22,6 +23,7 @@ div {
 
 div {
     --width: calc(10% + 30px);
+    width: calc(.9%);
     width: calc(0px);
     line-height: calc(0);
     line-height: calc(2 + 3 * 4);

--- a/tests/specs/value/dimension.txt
+++ b/tests/specs/value/dimension.txt
@@ -20,31 +20,19 @@ div { frequency: 14.44kHz; }
 
 [expect]
 a {
-    width: 0em;
+    width: .0em;
 }
 
 a {
-    width: 0em;
+    width: .00em;
 }
 
 a {
-    width: 0.1em;
+    width: .10em;
 }
 
 a {
-    width: 0em;
-}
-
-a {
-    width: 0.1em;
-}
-
-a {
-    width: 0em;
-}
-
-a {
-    width: 0em;
+    width: 0.0em;
 }
 
 a {
@@ -52,27 +40,39 @@ a {
 }
 
 a {
-    width: 0em;
+    width: +.0em;
 }
 
 a {
-    width: 0.1em;
+    width: +.00em;
 }
 
 a {
-    width: -0em;
+    width: +.10em;
 }
 
 a {
-    width: -0em;
+    width: +0.0em;
 }
 
 a {
-    width: -0.1em;
+    width: +0.1em;
 }
 
 a {
-    width: -0em;
+    width: -.0em;
+}
+
+a {
+    width: -.00em;
+}
+
+a {
+    width: -.10em;
+}
+
+a {
+    width: -0.0em;
 }
 
 a {


### PR DESCRIPTION
do not use parsed value because it changes the user's number format
