### PR TITLE
Add a failing test for comments moving to the top

### DIFF
--- a/tests/specs/comments.txt
+++ b/tests/specs/comments.txt
@@ -1,0 +1,22 @@
+== should format layer value ==
+
+.rule {
+  /* NOTE: this comment should stay inside the rule */
+  max-width: 10ch;
+}
+
+/* NOTE: this comment should stay right above the rule2 */
+.rule2 {
+  color: pink;
+}
+
+[expect]
+.rule {
+  /* NOTE: this comment should stay inside the rule */
+  max-width: 10ch;
+}
+
+/* NOTE: this comment should stay right above the rule2 */
+.rule2 {
+  color: pink;
+}


### PR DESCRIPTION
Comments always move to the top. I looked, but I'm uncertain what change would need to be made for them to keep their position in the output. I wanted to submit a failing test to illustrate the issue.